### PR TITLE
fix(rails_command): allow rake as command for legacy rails 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Definition and Completion provider for Rails Routes.
 - `railsRoutes.railsCommand`
   - `bin/rails` (default)
   - `bundle exec rails`
+  - `bin/rake` (legacy Rails < 5.0)
+  - `bundle exec rake` (legacy Rails < 5.0)
 
 ## TODO
 

--- a/package.json
+++ b/package.json
@@ -35,10 +35,12 @@
           "type": "string",
           "enum": [
             "bin/rails",
-            "bundle exec rails"
+            "bundle exec rails",
+            "bin/rake",
+            "bundle exec rake"
           ],
           "default": "bundle exec rails",
-          "description": "Rails command"
+          "description": "Rails command (rake is only applicable for legacy Rails versions)"
         }
       }
     },


### PR DESCRIPTION
Because Rails < 5.0 had the routes command in rake, not rails.
It is a simple change, and it will enable the extension to be usable on these
legacy Rails.

First I intended to do an issue, but looking at the changes that enable legacy Rails 4.2 to use the extensions, I decided that just converting this to a pull request takes approximately the same amount of time... :wink:

PS:  
I'm well aware that Rails 4 is totally out of date and actually should not be used any more, because it is unmaintained.  
But unfortunately I do not have a choice in one Project I have to work on.  
It can't get upgraded for now because of its dependencies `¯\_(ツ)_/¯`.


